### PR TITLE
 Remove /scan_aggregated remapping from launch files. 

### DIFF
--- a/cartographer_toru/launch/demo_toru_localization.launch
+++ b/cartographer_toru/launch/demo_toru_localization.launch
@@ -23,7 +23,6 @@
           -configuration_basename toru_localization.lua
           -map_filename $(arg map_filename)"
       output="screen">
-    <remap from="scan" to="/scan_aggregated" />
     <remap from="scan_1" to="/scan_front" />
     <remap from="scan_2" to="/scan_rear" />
     <remap from="imu" to="/imu/data_raw_transformed" />

--- a/cartographer_toru/launch/offline_toru_2d.launch
+++ b/cartographer_toru/launch/offline_toru_2d.launch
@@ -31,7 +31,6 @@
           -configuration_basenames toru.lua
           -bag_filenames $(arg bag_filenames)"
       output="screen">
-    <remap from="scan" to="/scan_aggregated" />
     <remap from="scan_1" to="/scan_front" />
     <remap from="scan_2" to="/scan_rear" />
     <remap from="imu" to="/imu/data_raw_transformed" />

--- a/cartographer_toru/launch/toru.launch
+++ b/cartographer_toru/launch/toru.launch
@@ -21,7 +21,6 @@
           -configuration_directory $(find cartographer_magazino)/configuration_files
           -configuration_basename toru.lua"
       output="screen">
-    <remap from="scan" to="/scan_aggregated" />
     <remap from="scan_1" to="/scan_front" />
     <remap from="scan_2" to="/scan_rear" />
     <remap from="imu" to="/imu/data_raw_transformed" />

--- a/cartographer_toru/launch/toru_simulation.launch
+++ b/cartographer_toru/launch/toru_simulation.launch
@@ -21,7 +21,6 @@
           -configuration_directory $(find cartographer_toru)/configuration_files
           -configuration_basename toru_simulation.lua"
       output="screen">
-    <remap from="scan" to="/scan_aggregated" />
     <remap from="scan_1" to="/scan_front" />
     <remap from="scan_2" to="/scan_rear" />
     <remap from="imu" to="/imu/data_raw_transformed" />

--- a/datasets/.gitattributes
+++ b/datasets/.gitattributes
@@ -1,0 +1,1 @@
+*.bag filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Minor change included: adds `.gitattributes` file for Git LFS.