### PR TITLE
Replace Git LFS with a link to public dataset list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,16 +39,16 @@ Documentation
 We currently support bagfiles recorded on Magazino TORU robots. Support for
 other platforms like SOTO may be added in the future.
 
-Test datasets are located in the ``datasets`` directory. We use `Git LFS`_ to
-track these datasets.
+Download links for the public datasets of Magazino robots can be found on the 
+`Cartographer ROS Read the Docs site`_.
 
-.. _Git LFS: https://git-lfs.github.com/
+.. _Cartographer ROS Read the Docs site: https://google-cartographer-ros.readthedocs.io/en/latest/data.html#magazino
 
 TORU
 ====
 
 We provide two sample datasets for mapping and localization that were
-recorded in a hallway, you can find them in the ``datasets/toru`` directory.
+recorded in a hallway.
 
 Run the simulation demo (mapping) with the hallway dataset:
 

--- a/datasets/.gitattributes
+++ b/datasets/.gitattributes
@@ -1,1 +1,0 @@
-*.bag filter=lfs diff=lfs merge=lfs -text

--- a/datasets/toru/hallway_localization.bag
+++ b/datasets/toru/hallway_localization.bag
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9af90dadb9235f2755ed82bc56e1eadb70605982a52bcdd94ecd46c5a38052c
-size 42349482

--- a/datasets/toru/hallway_return.bag
+++ b/datasets/toru/hallway_return.bag
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:922b849abb47187f352c2cf2327f4df2496b924a13f7a6bdd1aa483f677de926
-size 107829965


### PR DESCRIPTION
Avoid GitHub's greedy bandwitdh billing plans and use only the Google
Cloud storage.